### PR TITLE
feat: :sparkles: add quickgen command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import { quickGen } from './commands/quick';
 import { Command } from "commander";
 
 import { generateTypes } from "./commands/generate";
@@ -24,5 +25,16 @@ program
   .action(async () => {
     await generateTypes();
   });
+
+program
+  .command("quickgen")
+  .description("quickly generate Typescript types based on your GraphQL Schema using Arguments instead of manual prompts. Useful for use in npm scripts.")
+  .argument('<url>', "Your Strapi URL")
+  .option('-p, --path <location>', 'File path where you want to save the generated types', './models/')
+  .option('-n, --file-name <filename>', 'File name of the generated types', 'types.ts')
+  .action(async (url, options) => {
+    await quickGen(url, options.path, options.fileName);
+  });
+
 
 program.parse(process.argv);

--- a/src/commands/quick.ts
+++ b/src/commands/quick.ts
@@ -1,0 +1,89 @@
+/**
+ * Module dependencies
+ */
+
+// Node.js core.
+import { join } from "path";
+
+// Extra feature for fs Node.js core module.
+import { ensureDir, outputFile } from "fs-extra";
+
+// CLI color mode.
+import { blue, green } from "chalk";
+
+// Codegen core.
+import { codegen } from "@graphql-codegen/core";
+import { Types } from "@graphql-codegen/plugin-helpers/types";
+
+// GraphQL Dependencies in order to use Codegen.
+import * as typescriptPlugin from "@graphql-codegen/typescript";
+import { printSchema, parse, GraphQLSchema } from "graphql";
+import { loadSchema } from "@graphql-tools/load";
+import { UrlLoader } from "@graphql-tools/url-loader";
+
+// Options get by the prompt.
+export interface GenerateOptions {
+  host: string;
+  name: string;
+  dir: string;
+}
+
+/**
+ * `$ strapi-sdk generate`
+ *
+ * Generate Typescript types based on your GraphQL Schema.
+ */
+
+export const quickGen = async (url: string, dir: string, name: string): Promise<void> => {
+  try {
+
+    // Build initial scope.
+    const scope = {
+      host: url,
+      outputDir: dir,
+      outputName: name,
+      filePath: join(`${dir}/${name}`),
+    };
+    /* remove "/" from scope.host in case it exists */
+    scope.host = scope.host.replace(/\/$/, "");
+
+    console.log(`${blue("Info")}: Generating types from GraphQL at ${green(scope.host + "/graphql")}.`);
+
+    // Load schema from Strapi API
+    const schema: GraphQLSchema = await loadSchema(`${scope.host}/graphql`, {
+      loaders: [new UrlLoader()],
+    });
+
+    // Build Codegen config.
+    const config: Types.GenerateOptions = {
+      schema: parse(printSchema(schema)),
+      filename: scope.outputName,
+      documents: [],
+      config: {},
+      plugins: [
+        {
+          typescript: {},
+        },
+      ],
+      pluginMap: {
+        typescript: typescriptPlugin,
+      },
+    };
+
+    // Generate types
+    const output: string = await codegen(config);
+
+    // Create output directorie recursively.
+    await ensureDir(scope.outputDir);
+
+    // Write the generated type.
+    await outputFile(scope.filePath, output);
+
+    // Log the success.
+    console.log(`${blue("Info")}: Generated your types at ${green(scope.filePath)}.`);
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+};


### PR DESCRIPTION
Added `$ strapi quickgen` sub-command to generate types without prompt. Useful for `$ npm run` scripts.
Command has this syntax:
```bash
$ strapi quickgen <url> [-p, --path <location>, default: "./models/"] [-n, --file-name <filename>, default: "types.ts"]
```
The rest is pretty much the same, it's just a quality of life change.